### PR TITLE
Add MQTT Test Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AmoraOS - IoT Edge Audio Platform and SDK
 
+> **Important:** AmoraOS is currently in early development stages. We are focused on creating a Minimum Viable Product (MVP) with core functionality. Features and APIs may change significantly as the project evolves.
+
 A Python implementation of an edge device audio system that provides a custom SDK for seamless integration with Waybox applications. This project migrates from Arch Linux to Debian Bookworm on Raspberry Pi music boxes, enabling sophisticated edge audio capabilities with cloud connectivity.
 
 > **Note:** The SDK now includes MQTT broker integration for real-time communication between devices and client applications, as well as Azure IoT Hub integration for device management and telemetry.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -159,9 +159,33 @@ await client.setVolume(80);
 await client.disconnect();
 ```
 
-## Test App
+## Test Apps
 
-The SDK includes a simple React test app for demonstration purposes. To run the test app:
+### MQTT Test Application
+
+The SDK includes an MQTT test application that demonstrates how to use the SDK to control the music player via MQTT commands. This serves as a proof of concept for the real-time communication implementation.
+
+To run the MQTT test application:
+
+```bash
+# Create a credentials file
+cd sdk
+poetry run python -m test_app.mqtt_test.run init --config credentials_configs.txt
+
+# Edit the credentials file with your MQTT broker and player configuration
+
+# Run the server component
+poetry run python -m test_app.mqtt_test.run server --config credentials_configs.txt
+
+# In another terminal, run the client component
+poetry run python -m test_app.mqtt_test.run client --config credentials_configs.txt
+```
+
+For more details, see the [MQTT Test Application README](test_app/mqtt_test/README.md).
+
+### React Test App
+
+The SDK also includes a simple React test app for demonstration purposes. To run the React test app:
 
 ```bash
 cd sdk/test_app

--- a/sdk/test_app/mqtt_test/README.md
+++ b/sdk/test_app/mqtt_test/README.md
@@ -1,0 +1,233 @@
+# MQTT Test Application for AmoraSDK
+
+This test application demonstrates how to use the AmoraSDK to control the music player via MQTT commands. It serves as a proof of concept for the real-time communication implementation in the AmoraOS project.
+
+## Overview
+
+The application consists of two components:
+
+1. **Server Component**: Sets up the player, configures MQTT broker communication, handles incoming commands, and broadcasts player status updates.
+2. **Client Component**: A CLI application that allows the user to send commands to the player and displays real-time player status updates.
+
+## Prerequisites
+
+- Python 3.9 or higher
+- Poetry (for dependency management)
+- MPD (Music Player Daemon) running on the server
+- MQTT broker (e.g., Mosquitto, HiveMQ, etc.)
+
+## Installation
+
+1. Clone the repository and navigate to the SDK directory:
+
+```bash
+git clone https://github.com/jpmarques19/amora-os.git
+cd amora-os/sdk
+```
+
+2. Install dependencies using Poetry:
+
+```bash
+poetry install
+```
+
+3. Create a credentials file:
+
+```bash
+poetry run python -m test_app.mqtt_test.run init --config credentials_configs.txt
+```
+
+4. Edit the credentials file with your MQTT broker and player configuration.
+
+## Configuration
+
+The application uses a JSON configuration file (`credentials_configs.txt`) with the following structure:
+
+```json
+{
+    "mqtt": {
+        "broker_url": "localhost",
+        "port": 1883,
+        "username": "your_username",
+        "password": "your_password",
+        "device_id": "amora-player-001",
+        "topic_prefix": "amora/devices",
+        "use_tls": false,
+        "keep_alive": 60,
+        "clean_session": true,
+        "reconnect_on_failure": true,
+        "max_reconnect_delay": 300,
+        "default_qos": 1
+    },
+    "player": {
+        "mpd_host": "localhost",
+        "mpd_port": 6600,
+        "storage_path": "/home/user/music",
+        "playlists_path": "/home/user/music/playlists",
+        "audio_backend": "pipewire",
+        "audio_device": "default",
+        "audio_volume": 80,
+        "dev_mode": true
+    }
+}
+```
+
+You can also use environment variables to override the configuration:
+
+- `MQTT_BROKER_URL`: MQTT broker URL
+- `MQTT_PORT`: MQTT broker port
+- `MQTT_USERNAME`: MQTT username
+- `MQTT_PASSWORD`: MQTT password
+- `MQTT_DEVICE_ID`: Device ID
+- `MPD_HOST`: MPD host
+- `MPD_PORT`: MPD port
+
+## Usage
+
+### Running the Server
+
+The server component connects to the MPD server and MQTT broker, handles incoming commands, and broadcasts player status updates.
+
+```bash
+poetry run python -m test_app.mqtt_test.run server --config credentials_configs.txt
+```
+
+### Running the Client
+
+The client component connects to the MQTT broker, sends commands to the server, and displays real-time player status updates.
+
+```bash
+poetry run python -m test_app.mqtt_test.run client --config credentials_configs.txt
+```
+
+### Client Commands
+
+The client provides a command-line interface with the following commands:
+
+- `play`: Start playback
+- `pause`: Pause playback
+- `stop`: Stop playback
+- `next`: Skip to next track
+- `prev` or `previous`: Skip to previous track
+- `vol <level>` or `volume <level>`: Set volume (0-100)
+- `status`: Get player status
+- `playlists`: Get available playlists
+- `playlist <name>`: Play a specific playlist
+- `quit` or `exit`: Exit the application
+
+## MQTT Communication
+
+The application uses the following MQTT topics for communication:
+
+- `amora/devices/<device_id>/commands`: Commands from client to server
+- `amora/devices/<device_id>/responses`: Command responses from server to client
+- `amora/devices/<device_id>/state`: Player state updates from server to client
+- `amora/devices/<device_id>/connection`: Connection status updates
+
+### Message Formats
+
+#### Command Message
+
+```json
+{
+    "command": "play",
+    "command_id": "550e8400-e29b-41d4-a716-446655440000",
+    "params": null,
+    "timestamp": 1620000000.0
+}
+```
+
+#### Response Message
+
+```json
+{
+    "command_id": "550e8400-e29b-41d4-a716-446655440000",
+    "result": true,
+    "message": "Play command executed",
+    "data": null,
+    "timestamp": 1620000001.0
+}
+```
+
+#### State Message
+
+```json
+{
+    "state": "play",
+    "current_song": {
+        "title": "Song Title",
+        "artist": "Artist Name",
+        "album": "Album Name",
+        "file": "path/to/song.mp3",
+        "duration": 180.0,
+        "position": 45.5
+    },
+    "volume": 80,
+    "repeat": false,
+    "random": false,
+    "timestamp": 1620000002.0
+}
+```
+
+## Architecture
+
+### Server Component
+
+The server component uses the following classes from the AmoraSDK:
+
+- `MusicPlayer`: Interfaces with MPD to control music playback
+- `BrokerManager`: Manages MQTT communication
+- `BrokerConfig`: Configures the MQTT broker connection
+- `TopicManager`: Manages MQTT topics
+
+The server registers command handlers for each supported command and periodically publishes player state updates.
+
+### Client Component
+
+The client component uses the following classes from the AmoraSDK:
+
+- `BrokerManager`: Manages MQTT communication
+- `BrokerConfig`: Configures the MQTT broker connection
+- `TopicManager`: Manages MQTT topics
+
+The client subscribes to state and response topics, sends commands to the server, and displays real-time player status updates using the curses library.
+
+## Troubleshooting
+
+### Connection Issues
+
+If you encounter connection issues:
+
+1. Check that your MQTT broker is running and accessible
+2. Verify that your credentials are correct
+3. Check that the MPD server is running and accessible
+4. Check the logs for error messages
+
+### Logging
+
+The application logs to the following files:
+
+- Server: Standard output
+- Client: `mqtt_client.log`
+
+## Development
+
+### Adding New Commands
+
+To add a new command:
+
+1. Add a command handler in the server component
+2. Update the client component to send the new command
+3. Update the README.md with the new command
+
+### Testing
+
+To test the application:
+
+1. Run the server component
+2. Run the client component
+3. Send commands from the client and verify that they are executed by the server
+
+## License
+
+This project is licensed under the same license as the AmoraOS project.

--- a/sdk/test_app/mqtt_test/__init__.py
+++ b/sdk/test_app/mqtt_test/__init__.py
@@ -1,0 +1,6 @@
+"""
+MQTT Test Application for AmoraSDK.
+
+This package contains a test application that demonstrates how to use the
+AmoraSDK to control the music player via MQTT commands.
+"""

--- a/sdk/test_app/mqtt_test/client/__init__.py
+++ b/sdk/test_app/mqtt_test/client/__init__.py
@@ -1,0 +1,6 @@
+"""
+Client component of the MQTT Test Application.
+
+This module implements a CLI application that allows the user to send commands
+to the player via MQTT and display real-time player status updates.
+"""

--- a/sdk/test_app/mqtt_test/client/client.py
+++ b/sdk/test_app/mqtt_test/client/client.py
@@ -1,0 +1,441 @@
+"""
+MQTT Test Client
+
+This module implements a CLI application that allows the user to send commands
+to the player via MQTT and display real-time player status updates.
+"""
+
+import asyncio
+import logging
+import json
+import time
+import sys
+import os
+import signal
+import argparse
+from typing import Dict, Any, Optional, List
+import curses
+from datetime import datetime
+
+# Add the SDK to the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+# Import the SDK modules
+from amora_sdk.device.broker import (
+    BrokerManager, BrokerConfig, ConnectionOptions, QoS,
+    Message, StateMessage, CommandMessage, ResponseMessage
+)
+from amora_sdk.device.broker.topics import TopicType, TopicManager
+
+# Import the config module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+from config import get_mqtt_config
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    filename='mqtt_client.log'  # Log to file to avoid interfering with curses
+)
+logger = logging.getLogger(__name__)
+
+class MQTTTestClient:
+    """
+    MQTT Test Client for demonstrating the Amora SDK.
+    
+    This class implements a CLI application that allows the user to send commands
+    to the player via MQTT and display real-time player status updates.
+    """
+    
+    def __init__(self, mqtt_config: Dict[str, Any]):
+        """
+        Initialize the MQTT Test Client.
+        
+        Args:
+            mqtt_config: MQTT configuration
+        """
+        self.mqtt_config = mqtt_config
+        
+        # Create broker manager
+        self.broker_manager = self._create_broker_manager()
+        
+        # Player state
+        self.player_state: Optional[StateMessage] = None
+        
+        # Command responses
+        self.command_responses: Dict[str, ResponseMessage] = {}
+        
+        # Running flag
+        self.running = False
+        
+        # Curses screen
+        self.screen = None
+        
+        # Command history
+        self.command_history: List[str] = []
+        self.history_index = 0
+        
+        # Current command
+        self.current_command = ""
+        self.cursor_position = 0
+    
+    def _create_broker_manager(self) -> BrokerManager:
+        """
+        Create the broker manager.
+        
+        Returns:
+            BrokerManager instance
+        """
+        # Create connection options
+        connection_options = ConnectionOptions(
+            use_tls=self.mqtt_config.get("use_tls", False),
+            username=self.mqtt_config.get("username"),
+            password=self.mqtt_config.get("password"),
+            keep_alive=self.mqtt_config.get("keep_alive", 60),
+            clean_session=self.mqtt_config.get("clean_session", True),
+            reconnect_on_failure=self.mqtt_config.get("reconnect_on_failure", True),
+            max_reconnect_delay=self.mqtt_config.get("max_reconnect_delay", 300)
+        )
+        
+        # Create broker config
+        broker_config = BrokerConfig(
+            broker_url=self.mqtt_config.get("broker_url", "localhost"),
+            port=self.mqtt_config.get("port", 1883),
+            client_id=self.mqtt_config.get("client_id", f"amora-client-{int(time.time())}"),
+            device_id=self.mqtt_config.get("device_id", "amora-player-001"),
+            topic_prefix=self.mqtt_config.get("topic_prefix", "amora/devices"),
+            connection_options=connection_options,
+            default_qos=QoS(self.mqtt_config.get("default_qos", 1))
+        )
+        
+        # Create broker manager
+        broker_manager = BrokerManager(broker_config)
+        
+        # Set up state change callback
+        broker_manager.register_state_change_callback(self._on_state_change)
+        
+        # Set up response callback
+        broker_manager.register_response_callback(self._on_response)
+        
+        return broker_manager
+    
+    def _on_state_change(self, state: StateMessage) -> None:
+        """
+        Handle state change.
+        
+        Args:
+            state: State message
+        """
+        self.player_state = state
+        self._update_display()
+    
+    def _on_response(self, response: ResponseMessage) -> None:
+        """
+        Handle command response.
+        
+        Args:
+            response: Response message
+        """
+        self.command_responses[response.command_id] = response
+        self._update_display()
+    
+    def _update_display(self) -> None:
+        """Update the display with current state and responses."""
+        if not self.screen:
+            return
+        
+        try:
+            # Clear screen
+            self.screen.clear()
+            
+            # Get screen dimensions
+            height, width = self.screen.getmaxyx()
+            
+            # Display header
+            self.screen.addstr(0, 0, "=== MQTT Test Client ===", curses.A_BOLD)
+            self.screen.addstr(1, 0, f"Connected to: {self.mqtt_config.get('broker_url')}:{self.mqtt_config.get('port')}")
+            self.screen.addstr(2, 0, f"Device ID: {self.mqtt_config.get('device_id')}")
+            self.screen.addstr(3, 0, "=" * (width - 1))
+            
+            # Display player state
+            if self.player_state:
+                self.screen.addstr(5, 0, "Player State:", curses.A_BOLD)
+                self.screen.addstr(6, 0, f"State: {self.player_state.state}")
+                self.screen.addstr(7, 0, f"Volume: {self.player_state.volume}%")
+                
+                if self.player_state.current_song:
+                    song = self.player_state.current_song
+                    self.screen.addstr(9, 0, "Current Song:", curses.A_BOLD)
+                    self.screen.addstr(10, 0, f"Title: {song.get('title', 'Unknown')}")
+                    self.screen.addstr(11, 0, f"Artist: {song.get('artist', 'Unknown')}")
+                    self.screen.addstr(12, 0, f"Album: {song.get('album', 'Unknown')}")
+                    
+                    # Display progress bar if duration is available
+                    if 'duration' in song and 'position' in song:
+                        duration = song.get('duration', 0)
+                        position = song.get('position', 0)
+                        
+                        if duration > 0:
+                            progress = int((position / duration) * (width - 20))
+                            progress_bar = "[" + "=" * progress + " " * (width - 20 - progress) + "]"
+                            
+                            # Format time as MM:SS
+                            position_str = f"{int(position) // 60}:{int(position) % 60:02d}"
+                            duration_str = f"{int(duration) // 60}:{int(duration) % 60:02d}"
+                            
+                            self.screen.addstr(13, 0, f"Time: {position_str}/{duration_str}")
+                            self.screen.addstr(14, 0, progress_bar)
+            
+            # Display command help
+            self.screen.addstr(height - 10, 0, "Commands:", curses.A_BOLD)
+            self.screen.addstr(height - 9, 0, "play - Start playback")
+            self.screen.addstr(height - 8, 0, "pause - Pause playback")
+            self.screen.addstr(height - 7, 0, "stop - Stop playback")
+            self.screen.addstr(height - 6, 0, "next - Skip to next track")
+            self.screen.addstr(height - 5, 0, "prev - Skip to previous track")
+            self.screen.addstr(height - 4, 0, "vol <level> - Set volume (0-100)")
+            self.screen.addstr(height - 3, 0, "quit - Exit the application")
+            
+            # Display command input
+            self.screen.addstr(height - 2, 0, "=" * (width - 1))
+            self.screen.addstr(height - 1, 0, "> " + self.current_command)
+            
+            # Position cursor
+            self.screen.move(height - 1, 2 + self.cursor_position)
+            
+            # Refresh screen
+            self.screen.refresh()
+        except Exception as e:
+            logger.error(f"Error updating display: {e}")
+    
+    def _send_command(self, command: str, params: Optional[Dict[str, Any]] = None) -> None:
+        """
+        Send a command to the player.
+        
+        Args:
+            command: Command name
+            params: Command parameters
+        """
+        # Create command message
+        command_message = CommandMessage(
+            command=command,
+            params=params,
+            timestamp=time.time()
+        )
+        
+        # Publish command
+        topic = self.broker_manager.topic_manager.get_topic(TopicType.COMMANDS)
+        self.broker_manager.mqtt_client.publish(
+            topic=topic,
+            payload=command_message.to_json(),
+            qos=self.broker_manager.config.default_qos
+        )
+    
+    def _process_command(self, command_line: str) -> None:
+        """
+        Process a command line.
+        
+        Args:
+            command_line: Command line to process
+        """
+        # Add to command history
+        if command_line:
+            self.command_history.append(command_line)
+            self.history_index = len(self.command_history)
+        
+        # Split command line into parts
+        parts = command_line.strip().split()
+        if not parts:
+            return
+        
+        command = parts[0].lower()
+        
+        if command == "quit" or command == "exit":
+            self.running = False
+        elif command == "play":
+            self._send_command("play")
+        elif command == "pause":
+            self._send_command("pause")
+        elif command == "stop":
+            self._send_command("stop")
+        elif command == "next":
+            self._send_command("next")
+        elif command == "prev" or command == "previous":
+            self._send_command("previous")
+        elif command == "vol" or command == "volume":
+            if len(parts) > 1:
+                try:
+                    volume = int(parts[1])
+                    self._send_command("setVolume", {"volume": volume})
+                except ValueError:
+                    pass
+        elif command == "status":
+            self._send_command("getStatus")
+        elif command == "playlists":
+            self._send_command("getPlaylists")
+        elif command == "playlist" and len(parts) > 1:
+            self._send_command("playPlaylist", {"playlist": parts[1]})
+    
+    def _handle_key(self, key: int) -> None:
+        """
+        Handle a key press.
+        
+        Args:
+            key: Key code
+        """
+        if key == curses.KEY_ENTER or key == 10 or key == 13:
+            # Process command
+            self._process_command(self.current_command)
+            self.current_command = ""
+            self.cursor_position = 0
+        elif key == curses.KEY_BACKSPACE or key == 127 or key == 8:
+            # Backspace
+            if self.cursor_position > 0:
+                self.current_command = (
+                    self.current_command[:self.cursor_position - 1] +
+                    self.current_command[self.cursor_position:]
+                )
+                self.cursor_position -= 1
+        elif key == curses.KEY_DC:
+            # Delete
+            if self.cursor_position < len(self.current_command):
+                self.current_command = (
+                    self.current_command[:self.cursor_position] +
+                    self.current_command[self.cursor_position + 1:]
+                )
+        elif key == curses.KEY_LEFT:
+            # Left arrow
+            if self.cursor_position > 0:
+                self.cursor_position -= 1
+        elif key == curses.KEY_RIGHT:
+            # Right arrow
+            if self.cursor_position < len(self.current_command):
+                self.cursor_position += 1
+        elif key == curses.KEY_UP:
+            # Up arrow (command history)
+            if self.command_history and self.history_index > 0:
+                self.history_index -= 1
+                self.current_command = self.command_history[self.history_index]
+                self.cursor_position = len(self.current_command)
+        elif key == curses.KEY_DOWN:
+            # Down arrow (command history)
+            if self.history_index < len(self.command_history) - 1:
+                self.history_index += 1
+                self.current_command = self.command_history[self.history_index]
+                self.cursor_position = len(self.current_command)
+            elif self.history_index == len(self.command_history) - 1:
+                self.history_index = len(self.command_history)
+                self.current_command = ""
+                self.cursor_position = 0
+        elif key == curses.KEY_HOME:
+            # Home
+            self.cursor_position = 0
+        elif key == curses.KEY_END:
+            # End
+            self.cursor_position = len(self.current_command)
+        elif 32 <= key <= 126:
+            # Printable character
+            self.current_command = (
+                self.current_command[:self.cursor_position] +
+                chr(key) +
+                self.current_command[self.cursor_position:]
+            )
+            self.cursor_position += 1
+    
+    async def _input_loop(self) -> None:
+        """Handle user input."""
+        while self.running:
+            try:
+                # Get key
+                key = self.screen.getch()
+                
+                # Handle key
+                if key != -1:
+                    self._handle_key(key)
+                    self._update_display()
+                
+                # Sleep a bit to avoid high CPU usage
+                await asyncio.sleep(0.01)
+            except Exception as e:
+                logger.error(f"Error handling input: {e}")
+                await asyncio.sleep(1)
+    
+    async def start(self, screen) -> None:
+        """
+        Start the client.
+        
+        Args:
+            screen: Curses screen
+        """
+        # Save screen
+        self.screen = screen
+        
+        # Configure curses
+        curses.curs_set(1)  # Show cursor
+        curses.use_default_colors()  # Use terminal's default colors
+        self.screen.nodelay(True)  # Non-blocking input
+        self.screen.keypad(True)  # Enable special keys
+        
+        logger.info("Starting MQTT Test Client")
+        
+        # Connect to broker
+        logger.info("Connecting to MQTT broker")
+        if not self.broker_manager.connect():
+            logger.error("Failed to connect to MQTT broker")
+            return
+        
+        # Set running flag
+        self.running = True
+        
+        # Start input loop
+        input_task = asyncio.create_task(self._input_loop())
+        
+        # Initial display update
+        self._update_display()
+        
+        # Wait for input loop to finish
+        try:
+            await input_task
+        except asyncio.CancelledError:
+            pass
+    
+    async def stop(self) -> None:
+        """Stop the client."""
+        logger.info("Stopping MQTT Test Client")
+        
+        # Set running flag
+        self.running = False
+        
+        # Disconnect from broker
+        self.broker_manager.disconnect()
+        
+        logger.info("MQTT Test Client stopped")
+
+async def main():
+    """Main function."""
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="MQTT Test Client")
+    parser.add_argument("--config", help="Path to credentials file", default="credentials_configs.txt")
+    args = parser.parse_args()
+    
+    # Load configuration
+    mqtt_config = get_mqtt_config(args.config)
+    
+    # Check if MQTT configuration is valid
+    if not mqtt_config.get("broker_url"):
+        print("Error: MQTT broker URL not specified")
+        print("Please create a credentials_configs.txt file with MQTT configuration")
+        print("or set the MQTT_BROKER_URL environment variable")
+        return
+    
+    # Create client
+    client = MQTTTestClient(mqtt_config)
+    
+    # Start client with curses
+    await curses.wrapper(client.start)
+    
+    # Stop client
+    await client.stop()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdk/test_app/mqtt_test/config.py
+++ b/sdk/test_app/mqtt_test/config.py
@@ -1,0 +1,85 @@
+"""
+Configuration module for the MQTT test application.
+
+This module handles loading configuration from files and environment variables.
+"""
+
+import os
+import json
+import logging
+from typing import Dict, Any, Optional
+
+logger = logging.getLogger(__name__)
+
+def load_credentials_file(file_path: str) -> Dict[str, Any]:
+    """
+    Load credentials from a file.
+    
+    Args:
+        file_path: Path to the credentials file
+        
+    Returns:
+        Dictionary containing the credentials
+    """
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        logger.error(f"Credentials file not found: {file_path}")
+        return {}
+    except json.JSONDecodeError:
+        logger.error(f"Invalid JSON in credentials file: {file_path}")
+        return {}
+    except Exception as e:
+        logger.error(f"Error loading credentials file: {e}")
+        return {}
+
+def get_mqtt_config(credentials_file: str = "credentials_configs.txt") -> Dict[str, Any]:
+    """
+    Get MQTT configuration from credentials file or environment variables.
+    
+    Args:
+        credentials_file: Path to the credentials file
+        
+    Returns:
+        Dictionary containing MQTT configuration
+    """
+    # Try to load from credentials file
+    credentials = load_credentials_file(credentials_file)
+    mqtt_config = credentials.get("mqtt", {})
+    
+    # Override with environment variables if available
+    if os.environ.get("MQTT_BROKER_URL"):
+        mqtt_config["broker_url"] = os.environ.get("MQTT_BROKER_URL")
+    if os.environ.get("MQTT_PORT"):
+        mqtt_config["port"] = int(os.environ.get("MQTT_PORT"))
+    if os.environ.get("MQTT_USERNAME"):
+        mqtt_config["username"] = os.environ.get("MQTT_USERNAME")
+    if os.environ.get("MQTT_PASSWORD"):
+        mqtt_config["password"] = os.environ.get("MQTT_PASSWORD")
+    if os.environ.get("MQTT_DEVICE_ID"):
+        mqtt_config["device_id"] = os.environ.get("MQTT_DEVICE_ID")
+    
+    return mqtt_config
+
+def get_player_config(credentials_file: str = "credentials_configs.txt") -> Dict[str, Any]:
+    """
+    Get player configuration from credentials file or environment variables.
+    
+    Args:
+        credentials_file: Path to the credentials file
+        
+    Returns:
+        Dictionary containing player configuration
+    """
+    # Try to load from credentials file
+    credentials = load_credentials_file(credentials_file)
+    player_config = credentials.get("player", {})
+    
+    # Override with environment variables if available
+    if os.environ.get("MPD_HOST"):
+        player_config["mpd_host"] = os.environ.get("MPD_HOST")
+    if os.environ.get("MPD_PORT"):
+        player_config["mpd_port"] = int(os.environ.get("MPD_PORT"))
+    
+    return player_config

--- a/sdk/test_app/mqtt_test/credentials_template.json
+++ b/sdk/test_app/mqtt_test/credentials_template.json
@@ -1,0 +1,26 @@
+{
+    "mqtt": {
+        "broker_url": "localhost",
+        "port": 1883,
+        "username": "your_username",
+        "password": "your_password",
+        "device_id": "amora-player-001",
+        "topic_prefix": "amora/devices",
+        "use_tls": false,
+        "keep_alive": 60,
+        "clean_session": true,
+        "reconnect_on_failure": true,
+        "max_reconnect_delay": 300,
+        "default_qos": 1
+    },
+    "player": {
+        "mpd_host": "localhost",
+        "mpd_port": 6600,
+        "storage_path": "/home/user/music",
+        "playlists_path": "/home/user/music/playlists",
+        "audio_backend": "pipewire",
+        "audio_device": "default",
+        "audio_volume": 80,
+        "dev_mode": true
+    }
+}

--- a/sdk/test_app/mqtt_test/run.py
+++ b/sdk/test_app/mqtt_test/run.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Run script for the MQTT Test Application.
+
+This script provides a command-line interface to run either the client or server
+component of the MQTT Test Application.
+"""
+
+import argparse
+import asyncio
+import sys
+import os
+import logging
+import json
+import curses
+from typing import Dict, Any
+
+# Add the current directory to the path
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+# Import the client and server modules
+from client.client import MQTTTestClient
+from server.server import MQTTTestServer
+from config import get_mqtt_config, get_player_config
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+def create_credentials_file(output_path: str) -> None:
+    """
+    Create a credentials file template.
+    
+    Args:
+        output_path: Path to save the credentials file
+    """
+    # Load the template
+    template_path = os.path.join(os.path.dirname(__file__), "credentials_template.json")
+    try:
+        with open(template_path, "r") as f:
+            template = json.load(f)
+    except Exception as e:
+        logger.error(f"Error loading template: {e}")
+        return
+    
+    # Save the template to the output path
+    try:
+        with open(output_path, "w") as f:
+            json.dump(template, f, indent=4)
+        print(f"Credentials template saved to {output_path}")
+        print("Please edit this file with your MQTT broker and player configuration")
+    except Exception as e:
+        logger.error(f"Error saving template: {e}")
+
+async def run_client(config_path: str) -> None:
+    """
+    Run the client component.
+    
+    Args:
+        config_path: Path to the credentials file
+    """
+    # Load configuration
+    mqtt_config = get_mqtt_config(config_path)
+    
+    # Check if MQTT configuration is valid
+    if not mqtt_config.get("broker_url"):
+        print("Error: MQTT broker URL not specified")
+        print(f"Please edit {config_path} with your MQTT broker configuration")
+        print("or set the MQTT_BROKER_URL environment variable")
+        return
+    
+    # Create client
+    client = MQTTTestClient(mqtt_config)
+    
+    # Start client with curses
+    await curses.wrapper(client.start)
+    
+    # Stop client
+    await client.stop()
+
+async def run_server(config_path: str) -> None:
+    """
+    Run the server component.
+    
+    Args:
+        config_path: Path to the credentials file
+    """
+    # Load configuration
+    mqtt_config = get_mqtt_config(config_path)
+    player_config = get_player_config(config_path)
+    
+    # Check if MQTT configuration is valid
+    if not mqtt_config.get("broker_url"):
+        print("Error: MQTT broker URL not specified")
+        print(f"Please edit {config_path} with your MQTT broker configuration")
+        print("or set the MQTT_BROKER_URL environment variable")
+        return
+    
+    # Create server
+    server = MQTTTestServer(mqtt_config, player_config)
+    
+    # Start server
+    await server.start()
+    
+    # Keep running until stopped
+    try:
+        while server.running:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await server.stop()
+
+def main():
+    """Main function."""
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description="MQTT Test Application")
+    parser.add_argument("component", choices=["client", "server", "init"],
+                        help="Component to run (client, server, or init to create credentials file)")
+    parser.add_argument("--config", help="Path to credentials file", default="credentials_configs.txt")
+    args = parser.parse_args()
+    
+    # Run the selected component
+    if args.component == "client":
+        asyncio.run(run_client(args.config))
+    elif args.component == "server":
+        asyncio.run(run_server(args.config))
+    elif args.component == "init":
+        create_credentials_file(args.config)
+
+if __name__ == "__main__":
+    main()

--- a/sdk/test_app/mqtt_test/server/__init__.py
+++ b/sdk/test_app/mqtt_test/server/__init__.py
@@ -1,0 +1,7 @@
+"""
+Server component of the MQTT Test Application.
+
+This module implements a server that uses the Amora SDK to set up the player,
+configure MQTT broker communication, handle incoming commands from the client,
+and broadcast player status updates via MQTT.
+"""

--- a/sdk/test_app/mqtt_test/server/server.py
+++ b/sdk/test_app/mqtt_test/server/server.py
@@ -1,0 +1,439 @@
+"""
+MQTT Test Server
+
+This module implements a server that uses the Amora SDK to set up the player,
+configure MQTT broker communication, handle incoming commands from the client,
+and broadcast player status updates via MQTT.
+"""
+
+import asyncio
+import logging
+import json
+import time
+import sys
+import os
+import signal
+from typing import Dict, Any, Optional
+
+# Add the SDK to the path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+# Import the SDK modules
+from amora_sdk.device.broker import (
+    BrokerManager, BrokerConfig, ConnectionOptions, QoS,
+    Message, StateMessage, CommandMessage, ResponseMessage
+)
+from amora_sdk.device.broker.topics import TopicType
+from amora_sdk.device.player.music_player import MusicPlayer
+
+# Import the config module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+from config import get_mqtt_config, get_player_config
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+class MQTTTestServer:
+    """
+    MQTT Test Server for demonstrating the Amora SDK.
+    
+    This class sets up a server that uses the Amora SDK to control the music player
+    via MQTT commands and broadcast player status updates.
+    """
+    
+    def __init__(self, mqtt_config: Dict[str, Any], player_config: Dict[str, Any]):
+        """
+        Initialize the MQTT Test Server.
+        
+        Args:
+            mqtt_config: MQTT configuration
+            player_config: Player configuration
+        """
+        self.mqtt_config = mqtt_config
+        self.player_config = player_config
+        
+        # Create player interface
+        self.player = self._create_player()
+        
+        # Create broker manager
+        self.broker_manager = self._create_broker_manager()
+        
+        # Set up command handlers
+        self._setup_command_handlers()
+        
+        # Status update interval in seconds
+        self.status_update_interval = 1.0
+        
+        # Running flag
+        self.running = False
+        
+        # Status update task
+        self.status_update_task = None
+    
+    def _create_player(self) -> MusicPlayer:
+        """
+        Create the player interface.
+        
+        Returns:
+            MusicPlayer instance
+        """
+        mpd_config = {
+            "mpd": {
+                "host": self.player_config.get("mpd_host", "localhost"),
+                "port": self.player_config.get("mpd_port", 6600)
+            },
+            "content": {
+                "storage_path": self.player_config.get("storage_path", "/home/user/music"),
+                "playlists_path": self.player_config.get("playlists_path", "/home/user/music/playlists")
+            },
+            "audio": {
+                "backend": self.player_config.get("audio_backend", "pipewire"),
+                "device": self.player_config.get("audio_device", "default"),
+                "volume": self.player_config.get("audio_volume", 80)
+            },
+            "dev_mode": self.player_config.get("dev_mode", True)
+        }
+        
+        player = MusicPlayer(mpd_config)
+        return player
+    
+    def _create_broker_manager(self) -> BrokerManager:
+        """
+        Create the broker manager.
+        
+        Returns:
+            BrokerManager instance
+        """
+        # Create connection options
+        connection_options = ConnectionOptions(
+            use_tls=self.mqtt_config.get("use_tls", False),
+            username=self.mqtt_config.get("username"),
+            password=self.mqtt_config.get("password"),
+            keep_alive=self.mqtt_config.get("keep_alive", 60),
+            clean_session=self.mqtt_config.get("clean_session", True),
+            reconnect_on_failure=self.mqtt_config.get("reconnect_on_failure", True),
+            max_reconnect_delay=self.mqtt_config.get("max_reconnect_delay", 300)
+        )
+        
+        # Create broker config
+        broker_config = BrokerConfig(
+            broker_url=self.mqtt_config.get("broker_url", "localhost"),
+            port=self.mqtt_config.get("port", 1883),
+            client_id=self.mqtt_config.get("client_id", f"amora-server-{int(time.time())}"),
+            device_id=self.mqtt_config.get("device_id", "amora-player-001"),
+            topic_prefix=self.mqtt_config.get("topic_prefix", "amora/devices"),
+            connection_options=connection_options,
+            default_qos=QoS(self.mqtt_config.get("default_qos", 1))
+        )
+        
+        # Create broker manager
+        broker_manager = BrokerManager(broker_config, self.player)
+        return broker_manager
+    
+    def _setup_command_handlers(self) -> None:
+        """Set up command handlers for the broker manager."""
+        # Register command handlers
+        self.broker_manager.register_command_handler("play", self._handle_play)
+        self.broker_manager.register_command_handler("pause", self._handle_pause)
+        self.broker_manager.register_command_handler("stop", self._handle_stop)
+        self.broker_manager.register_command_handler("next", self._handle_next)
+        self.broker_manager.register_command_handler("previous", self._handle_previous)
+        self.broker_manager.register_command_handler("setVolume", self._handle_set_volume)
+        self.broker_manager.register_command_handler("getStatus", self._handle_get_status)
+        self.broker_manager.register_command_handler("getPlaylists", self._handle_get_playlists)
+        self.broker_manager.register_command_handler("playPlaylist", self._handle_play_playlist)
+    
+    async def _handle_play(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle play command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling play command")
+        result = self.player.play()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message="Play command executed",
+            timestamp=time.time()
+        )
+    
+    async def _handle_pause(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle pause command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling pause command")
+        result = self.player.pause()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message="Pause command executed",
+            timestamp=time.time()
+        )
+    
+    async def _handle_stop(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle stop command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling stop command")
+        result = self.player.stop()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message="Stop command executed",
+            timestamp=time.time()
+        )
+    
+    async def _handle_next(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle next command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling next command")
+        result = self.player.next()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message="Next command executed",
+            timestamp=time.time()
+        )
+    
+    async def _handle_previous(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle previous command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling previous command")
+        result = self.player.previous()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message="Previous command executed",
+            timestamp=time.time()
+        )
+    
+    async def _handle_set_volume(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle setVolume command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling setVolume command")
+        params = command.params or {}
+        volume = params.get("volume", 50)
+        
+        result = self.player.set_volume(volume)
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message=f"Volume set to {volume}",
+            timestamp=time.time()
+        )
+    
+    async def _handle_get_status(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle getStatus command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling getStatus command")
+        status = self.player.get_status()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=True,
+            message="Status retrieved",
+            data={"status": status},
+            timestamp=time.time()
+        )
+    
+    async def _handle_get_playlists(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle getPlaylists command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling getPlaylists command")
+        playlists = self.player.get_playlists()
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=True,
+            message="Playlists retrieved",
+            data={"playlists": playlists},
+            timestamp=time.time()
+        )
+    
+    async def _handle_play_playlist(self, command: CommandMessage) -> ResponseMessage:
+        """
+        Handle playPlaylist command.
+        
+        Args:
+            command: Command message
+            
+        Returns:
+            Response message
+        """
+        logger.info("Handling playPlaylist command")
+        params = command.params or {}
+        playlist = params.get("playlist")
+        
+        if not playlist:
+            return ResponseMessage(
+                command_id=command.command_id,
+                result=False,
+                message="No playlist specified",
+                timestamp=time.time()
+            )
+        
+        result = self.player.play_playlist(playlist)
+        return ResponseMessage(
+            command_id=command.command_id,
+            result=result,
+            message=f"Playing playlist {playlist}",
+            timestamp=time.time()
+        )
+    
+    async def _update_status(self) -> None:
+        """Periodically update and publish player status."""
+        while self.running:
+            try:
+                # Get player status
+                status = self.player.get_status()
+                
+                # Create state message
+                state_message = StateMessage.from_player_state(status)
+                
+                # Publish state
+                self.broker_manager.publish_state(state_message)
+                
+                # Wait for next update
+                await asyncio.sleep(self.status_update_interval)
+            except Exception as e:
+                logger.error(f"Error updating status: {e}")
+                await asyncio.sleep(1)  # Wait a bit before retrying
+    
+    async def start(self) -> None:
+        """Start the server."""
+        logger.info("Starting MQTT Test Server")
+        
+        # Connect to player
+        if not self.player.connected:
+            logger.info("Connecting to player")
+            if not self.player.connect():
+                logger.error("Failed to connect to player")
+                return
+        
+        # Connect to broker
+        logger.info("Connecting to MQTT broker")
+        if not self.broker_manager.connect():
+            logger.error("Failed to connect to MQTT broker")
+            return
+        
+        # Set running flag
+        self.running = True
+        
+        # Start status update task
+        self.status_update_task = asyncio.create_task(self._update_status())
+        
+        logger.info("MQTT Test Server started")
+    
+    async def stop(self) -> None:
+        """Stop the server."""
+        logger.info("Stopping MQTT Test Server")
+        
+        # Set running flag
+        self.running = False
+        
+        # Cancel status update task
+        if self.status_update_task:
+            self.status_update_task.cancel()
+            try:
+                await self.status_update_task
+            except asyncio.CancelledError:
+                pass
+        
+        # Disconnect from broker
+        self.broker_manager.disconnect()
+        
+        # Disconnect from player
+        self.player.disconnect()
+        
+        logger.info("MQTT Test Server stopped")
+
+async def main():
+    """Main function."""
+    # Load configuration
+    mqtt_config = get_mqtt_config()
+    player_config = get_player_config()
+    
+    # Check if MQTT configuration is valid
+    if not mqtt_config.get("broker_url"):
+        logger.error("MQTT broker URL not specified")
+        return
+    
+    # Create server
+    server = MQTTTestServer(mqtt_config, player_config)
+    
+    # Set up signal handlers
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, lambda: asyncio.create_task(shutdown(server)))
+    
+    # Start server
+    await server.start()
+    
+    # Keep running until stopped
+    try:
+        while server.running:
+            await asyncio.sleep(1)
+    finally:
+        await server.stop()
+
+async def shutdown(server: MQTTTestServer):
+    """Shutdown the server."""
+    logger.info("Shutting down...")
+    await server.stop()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## MQTT Test Application

This PR adds a test application that demonstrates how to use our SDK to control the music player via MQTT commands. It serves as a proof of concept for our real-time communication implementation.

### Changes

- Updated the project documentation to clearly state that AmoraOS is in early development stages and focused on creating an MVP
- Created a test application with two components:
  - Server component: Sets up the player, configures MQTT broker communication, handles incoming commands, and broadcasts player status updates
  - Client component: A CLI application that allows the user to send commands to the player and displays real-time player status updates
- Added comprehensive documentation for the test application

### How to Test

1. Clone this branch
2. Navigate to the SDK directory: `cd amora-os/sdk`
3. Install dependencies: `poetry install`
4. Create a credentials file: `poetry run python -m test_app.mqtt_test.run init --config credentials_configs.txt`
5. Edit the credentials file with your MQTT broker and player configuration
6. Run the server component: `poetry run python -m test_app.mqtt_test.run server --config credentials_configs.txt`
7. In another terminal, run the client component: `poetry run python -m test_app.mqtt_test.run client --config credentials_configs.txt`

For more details, see the [MQTT Test Application README](sdk/test_app/mqtt_test/README.md).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author