### PR TITLE
Update Amora Client SDK to match new API schema

### DIFF
--- a/amora-sdk/client/.eslintrc.js
+++ b/amora-sdk/client/.eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+  env: {
+    node: true,
+    jest: true,
+  },
+  rules: {
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+    'no-console': ['warn', { allow: ['warn', 'error'] }],
+  },
+};

--- a/amora-sdk/client/.gitignore
+++ b/amora-sdk/client/.gitignore
@@ -1,0 +1,38 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+dist/
+lib/
+build/
+
+# Coverage
+coverage/
+
+# IDE files
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+
+# Temporary files
+tmp/
+temp/

--- a/amora-sdk/client/.prettierrc
+++ b/amora-sdk/client/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/amora-sdk/client/README.md
+++ b/amora-sdk/client/README.md
@@ -1,0 +1,185 @@
+# Amora Client SDK
+
+A TypeScript/JavaScript SDK for controlling Amora music player devices through MQTT.
+
+## Features
+
+- Real-time status updates from the music player to the web app:
+  - Player state monitoring (playing, stopped, paused)
+  - Track playback position tracking (current time/duration)
+  - Track metadata retrieval (artist, title, album, cover art)
+  - Complete playlist management with all available tracks and their metadata
+
+- Control commands from the web app to the music player:
+  - Play/Pause/Stop controls
+  - Next/Previous track navigation
+  - Track selection from playlist
+  - Playlist manipulation (add/remove tracks, reorder)
+
+- Simple and intuitive API for web developers
+- Comprehensive error handling and connection management
+- Proper TypeScript typing for all public interfaces
+- Abstracts all MQTT communication complexity
+
+## Installation
+
+```bash
+npm install amora-client-sdk
+```
+
+## Quick Start
+
+```javascript
+const { AmoraClient, EventType } = require('amora-client-sdk');
+
+// Create client configuration
+const config = {
+  brokerUrl: 'localhost',
+  port: 1883,
+  deviceId: 'amora-player-001'
+};
+
+// Create client instance
+const client = new AmoraClient(config);
+
+// Set up event listeners
+client.on(EventType.STATE_CHANGE, (state) => {
+  console.log(`Player state changed: ${state}`);
+});
+
+// Connect to the MQTT broker
+async function run() {
+  try {
+    await client.connect();
+    console.log('Connected!');
+
+    // Control the player
+    await client.play();
+    
+    // Wait for 5 seconds
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    // Disconnect when done
+    await client.disconnect();
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+}
+
+// Run the example
+run();
+```
+
+## API Reference
+
+### AmoraClient
+
+The main client class for interacting with Amora music player devices.
+
+#### Constructor
+
+```typescript
+constructor(config: AmoraClientConfig)
+```
+
+Creates a new Amora client instance with the specified configuration.
+
+#### Configuration
+
+```typescript
+interface AmoraClientConfig {
+  brokerUrl: string;        // MQTT broker URL
+  port: number;             // MQTT broker port
+  clientId?: string;        // Client ID (auto-generated if not provided)
+  deviceId: string;         // Device ID to connect to
+  topicPrefix?: string;     // Topic prefix (default: 'amora/devices')
+  connectionOptions?: ConnectionOptions;  // Connection options
+  defaultQoS?: QoS;         // Default QoS level (default: AT_LEAST_ONCE)
+}
+```
+
+#### Connection Methods
+
+- `connect()`: Connect to the MQTT broker
+- `disconnect()`: Disconnect from the MQTT broker
+- `getConnectionStatus()`: Get the current connection status
+
+#### Player Control Methods
+
+- `play()`: Start playback
+- `pause()`: Pause playback
+- `stop()`: Stop playback
+- `next()`: Skip to the next track
+- `previous()`: Go back to the previous track
+- `setVolume(volume: number)`: Set the volume (0-100)
+- `getVolume()`: Get the current volume
+- `setRepeat(repeat: boolean)`: Set repeat mode
+- `setRandom(random: boolean)`: Set random mode
+- `getStatus()`: Get the current player status
+- `getPlaylists()`: Get the available playlists
+- `playPlaylist(playlist: string)`: Play a playlist
+- `getPlaylistSongs(playlist: string)`: Get songs in a playlist
+- `createPlaylist(name: string, files: string[])`: Create a new playlist
+- `deletePlaylist(playlist: string)`: Delete a playlist
+- `updateDatabase()`: Update the music database
+- `playTrack(trackIndex: number)`: Play a specific track
+- `addTrack(track: string, playlist: string)`: Add a track to a playlist
+- `removeTrack(trackIndex: number, playlist: string)`: Remove a track from a playlist
+- `reorderTrack(fromIndex: number, toIndex: number, playlist: string)`: Reorder tracks in a playlist
+
+#### Event Handling
+
+```typescript
+client.on(EventType.STATE_CHANGE, (state) => {
+  console.log(`Player state changed: ${state}`);
+});
+```
+
+Available event types:
+- `STATE_CHANGE`: Player state changed
+- `POSITION_CHANGE`: Playback position changed
+- `VOLUME_CHANGE`: Volume changed
+- `PLAYLIST_CHANGE`: Playlists updated
+- `CONNECTION_CHANGE`: Connection status changed
+- `COMMAND_RESPONSE`: Command response received
+- `ERROR`: Error occurred
+
+## Examples
+
+See the `examples` directory for more detailed examples:
+
+- `basic-usage.js`: Basic usage example
+
+## MQTT Topics
+
+The SDK uses the following MQTT topics for communication:
+
+- `{topicPrefix}/{deviceId}/state`: Player state updates
+- `{topicPrefix}/{deviceId}/commands`: Commands to the player
+- `{topicPrefix}/{deviceId}/responses`: Command responses from the player
+- `{topicPrefix}/{deviceId}/connection`: Connection status updates
+
+## Development
+
+### Building the SDK
+
+```bash
+npm install
+npm run build
+```
+
+### Running Tests
+
+```bash
+npm test
+```
+
+### Generating Documentation
+
+```bash
+npm run docs
+```
+
+## License
+
+MIT

--- a/amora-sdk/client/examples/basic-usage.js
+++ b/amora-sdk/client/examples/basic-usage.js
@@ -1,0 +1,107 @@
+/**
+ * Basic usage example for the Amora Client SDK
+ */
+
+const { AmoraClient, EventType, PlayerState } = require('../dist');
+
+// Create client configuration
+const config = {
+  brokerUrl: 'localhost',
+  port: 1883,
+  deviceId: 'amora-player-001',
+  connectionOptions: {
+    username: 'your_username',  // Optional
+    password: 'your_password',  // Optional
+    useTls: false,
+    keepAlive: 60,
+    cleanSession: true,
+    reconnectOnFailure: true
+  }
+};
+
+// Create client instance
+const client = new AmoraClient(config);
+
+// Set up event listeners
+client.on(EventType.CONNECTION_CHANGE, (status) => {
+  console.log(`Connection status changed: ${status}`);
+});
+
+client.on(EventType.STATE_CHANGE, (state) => {
+  console.log(`Player state changed: ${state}`);
+});
+
+client.on(EventType.POSITION_CHANGE, (position) => {
+  if (position !== undefined) {
+    const minutes = Math.floor(position / 60);
+    const seconds = Math.floor(position % 60);
+    console.log(`Position changed: ${minutes}:${seconds.toString().padStart(2, '0')}`);
+  }
+});
+
+client.on(EventType.VOLUME_CHANGE, (volume) => {
+  console.log(`Volume changed: ${volume}%`);
+});
+
+client.on(EventType.PLAYLIST_CHANGE, (playlists) => {
+  console.log(`Playlists updated: ${playlists.length} playlists available`);
+});
+
+client.on(EventType.ERROR, (error) => {
+  console.error(`Error: ${error.message}`);
+});
+
+// Connect to the MQTT broker
+async function run() {
+  try {
+    console.log('Connecting to MQTT broker...');
+    await client.connect();
+    console.log('Connected!');
+
+    // Get current status
+    const status = await client.getStatus();
+    console.log('Current status:', status);
+
+    // Get available playlists
+    const playlists = await client.getPlaylists();
+    console.log(`Available playlists: ${playlists.map(p => p.name).join(', ')}`);
+
+    // Control the player
+    console.log('Playing...');
+    await client.play();
+    
+    // Wait for 5 seconds
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    console.log('Pausing...');
+    await client.pause();
+    
+    // Wait for 2 seconds
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    console.log('Setting volume to 80%...');
+    await client.setVolume(80);
+    
+    // Wait for 2 seconds
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    
+    console.log('Playing next track...');
+    await client.next();
+    
+    // Wait for 5 seconds
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    
+    console.log('Stopping...');
+    await client.stop();
+    
+    // Disconnect when done
+    console.log('Disconnecting...');
+    await client.disconnect();
+    console.log('Disconnected!');
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+}
+
+// Run the example
+run();

--- a/amora-sdk/client/jest.config.js
+++ b/amora-sdk/client/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: 'tsconfig.json',
+    }],
+  },
+};

--- a/amora-sdk/client/package.json
+++ b/amora-sdk/client/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "amora-client-sdk",
+  "version": "0.1.0",
+  "description": "Amora Client SDK for controlling music player devices through MQTT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test && npm run lint",
+    "docs": "typedoc --out docs src"
+  },
+  "keywords": [
+    "amora",
+    "mqtt",
+    "music",
+    "player",
+    "sdk"
+  ],
+  "author": "Amora Team",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^18.15.11",
+    "@types/uuid": "^9.0.1",
+    "@typescript-eslint/eslint-plugin": "^5.57.1",
+    "@typescript-eslint/parser": "^5.57.1",
+    "eslint": "^8.38.0",
+    "jest": "^29.5.0",
+    "prettier": "^2.8.7",
+    "ts-jest": "^29.1.0",
+    "typedoc": "^0.24.1",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "mqtt": "^4.3.7",
+    "uuid": "^9.0.0"
+  },
+  "files": [
+    "dist/**/*"
+  ]
+}

--- a/amora-sdk/client/src/amora-client.ts
+++ b/amora-sdk/client/src/amora-client.ts
@@ -1,0 +1,451 @@
+/**
+ * Main client class for the Amora Client SDK
+ */
+
+import { EventEmitter } from 'events';
+import { MQTTClient } from './mqtt-client';
+import { TopicManager } from './topic-manager';
+import { createCommandMessage, parseMessage } from './messages';
+import {
+  AmoraClientConfig,
+  QoS,
+  PlayerStatus,
+  Playlist,
+  EventType,
+  EventListener,
+  TopicType,
+  ConnectionStatus,
+  CommandMessage,
+  ResponseMessage,
+  StateMessage,
+  PlayerState
+} from './types';
+
+/**
+ * Main client class for the Amora Client SDK
+ */
+export class AmoraClient extends EventEmitter {
+  private mqttClient: MQTTClient;
+  private topicManager: TopicManager;
+  private config: AmoraClientConfig;
+  private pendingCommands: Map<string, { resolve: Function; reject: Function; timestamp: number }> = new Map();
+  private commandTimeout = 10000; // 10 seconds
+  private commandTimeoutTimer: NodeJS.Timeout | null = null;
+  private playerStatus: PlayerStatus = {
+    state: PlayerState.STOPPED,
+    volume: 0,
+    repeat: false,
+    random: false
+  };
+  private playlists: Playlist[] = [];
+
+  /**
+   * Create a new Amora client
+   * @param config Client configuration
+   */
+  constructor(config: AmoraClientConfig) {
+    super();
+    this.config = {
+      ...config,
+      clientId: config.clientId || `amora-client-${Date.now()}`,
+      topicPrefix: config.topicPrefix || 'amora/devices',
+      defaultQoS: config.defaultQoS || QoS.AT_LEAST_ONCE
+    };
+    this.mqttClient = new MQTTClient(this.config);
+    this.topicManager = new TopicManager(this.config.topicPrefix!, this.config.deviceId);
+
+    // Set up event handlers
+    this.mqttClient.on('message', this.handleMessage.bind(this));
+    this.mqttClient.on('connectionChange', this.handleConnectionChange.bind(this));
+    this.mqttClient.on('error', (error) => this.emit(EventType.ERROR, error));
+
+    // Start command timeout checker
+    this.startCommandTimeoutChecker();
+  }
+
+  /**
+   * Connect to the MQTT broker
+   * @returns Promise that resolves when connected
+   */
+  public async connect(): Promise<void> {
+    try {
+      await this.mqttClient.connect();
+      
+      // Subscribe to topics
+      for (const topic of this.topicManager.getSubscriptionTopics()) {
+        await this.mqttClient.subscribe(topic);
+      }
+      
+      // Get initial status
+      await this.getStatus();
+    } catch (error) {
+      this.emit(EventType.ERROR, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Disconnect from the MQTT broker
+   */
+  public async disconnect(): Promise<void> {
+    try {
+      // Stop command timeout checker
+      if (this.commandTimeoutTimer) {
+        clearInterval(this.commandTimeoutTimer);
+        this.commandTimeoutTimer = null;
+      }
+      
+      // Reject all pending commands
+      for (const [commandId, { reject }] of this.pendingCommands.entries()) {
+        reject(new Error('Client disconnected'));
+        this.pendingCommands.delete(commandId);
+      }
+      
+      await this.mqttClient.disconnect();
+    } catch (error) {
+      this.emit(EventType.ERROR, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get the current connection status
+   */
+  public getConnectionStatus(): ConnectionStatus {
+    return this.mqttClient.getConnectionStatus();
+  }
+
+  /**
+   * Get the current player status
+   */
+  public getPlayerStatus(): PlayerStatus {
+    return { ...this.playerStatus };
+  }
+
+  /**
+   * Get the available playlists
+   */
+  public getPlaylists(): Playlist[] {
+    return [...this.playlists];
+  }
+
+  /**
+   * Register an event listener
+   * @param event Event type
+   * @param listener Event listener
+   */
+  public on(event: EventType, listener: EventListener): this {
+    return super.on(event, listener);
+  }
+
+  /**
+   * Remove an event listener
+   * @param event Event type
+   * @param listener Event listener
+   */
+  public off(event: EventType, listener: EventListener): this {
+    return super.off(event, listener);
+  }
+
+  /**
+   * Send a command to the player
+   * @param command Command name
+   * @param params Command parameters
+   * @returns Promise that resolves with the command response
+   */
+  private async sendCommand(command: string, params?: any): Promise<ResponseMessage> {
+    const commandMessage = createCommandMessage(command, params);
+    const topic = this.topicManager.getTopic(TopicType.COMMANDS);
+
+    return new Promise((resolve, reject) => {
+      // Add to pending commands
+      this.pendingCommands.set(commandMessage.commandId, {
+        resolve,
+        reject,
+        timestamp: Date.now()
+      });
+
+      // Send command
+      this.mqttClient.publish(topic, commandMessage)
+        .catch((error) => {
+          this.pendingCommands.delete(commandMessage.commandId);
+          reject(error);
+        });
+    });
+  }
+
+  /**
+   * Handle an incoming message
+   * @param topic Message topic
+   * @param payload Message payload
+   */
+  private handleMessage(topic: string, payload: Buffer): void {
+    const topicType = this.topicManager.parseTopic(topic);
+    if (!topicType) {
+      return;
+    }
+
+    const message = parseMessage(payload);
+    if (!message) {
+      return;
+    }
+
+    switch (topicType) {
+      case TopicType.STATE:
+        this.handleStateMessage(message as StateMessage);
+        break;
+      case TopicType.RESPONSES:
+        this.handleResponseMessage(message as ResponseMessage);
+        break;
+    }
+  }
+
+  /**
+   * Handle a state message
+   * @param message State message
+   */
+  private handleStateMessage(message: StateMessage): void {
+    const oldStatus = { ...this.playerStatus };
+    
+    // Update player status
+    this.playerStatus = {
+      state: message.state,
+      currentSong: message.currentSong,
+      volume: message.volume,
+      repeat: message.repeat,
+      random: message.random
+    };
+    
+    // Emit events for changes
+    if (oldStatus.state !== this.playerStatus.state) {
+      this.emit(EventType.STATE_CHANGE, this.playerStatus.state);
+    }
+    
+    if (oldStatus.currentSong?.position !== this.playerStatus.currentSong?.position) {
+      this.emit(EventType.POSITION_CHANGE, this.playerStatus.currentSong?.position);
+    }
+    
+    if (oldStatus.volume !== this.playerStatus.volume) {
+      this.emit(EventType.VOLUME_CHANGE, this.playerStatus.volume);
+    }
+  }
+
+  /**
+   * Handle a response message
+   * @param message Response message
+   */
+  private handleResponseMessage(message: ResponseMessage): void {
+    // Check if this is a response to a pending command
+    const pendingCommand = this.pendingCommands.get(message.commandId);
+    if (pendingCommand) {
+      // Remove from pending commands
+      this.pendingCommands.delete(message.commandId);
+      
+      // Resolve or reject the promise
+      if (message.result) {
+        pendingCommand.resolve(message);
+      } else {
+        pendingCommand.reject(new Error(message.message || 'Command failed'));
+      }
+    }
+    
+    // Emit event
+    this.emit(EventType.COMMAND_RESPONSE, message);
+    
+    // Handle specific responses
+    if (message.data) {
+      if (message.data.playlists) {
+        this.playlists = message.data.playlists;
+        this.emit(EventType.PLAYLIST_CHANGE, this.playlists);
+      }
+    }
+  }
+
+  /**
+   * Handle a connection change
+   * @param status New connection status
+   */
+  private handleConnectionChange(status: ConnectionStatus): void {
+    this.emit(EventType.CONNECTION_CHANGE, status);
+  }
+
+  /**
+   * Start the command timeout checker
+   */
+  private startCommandTimeoutChecker(): void {
+    this.commandTimeoutTimer = setInterval(() => {
+      const now = Date.now();
+      
+      for (const [commandId, { reject, timestamp }] of this.pendingCommands.entries()) {
+        if (now - timestamp > this.commandTimeout) {
+          reject(new Error('Command timed out'));
+          this.pendingCommands.delete(commandId);
+        }
+      }
+    }, 1000);
+  }
+
+  // Player control methods
+
+  /**
+   * Start playback
+   */
+  public async play(): Promise<void> {
+    await this.sendCommand('play');
+  }
+
+  /**
+   * Pause playback
+   */
+  public async pause(): Promise<void> {
+    await this.sendCommand('pause');
+  }
+
+  /**
+   * Stop playback
+   */
+  public async stop(): Promise<void> {
+    await this.sendCommand('stop');
+  }
+
+  /**
+   * Skip to the next track
+   */
+  public async next(): Promise<void> {
+    await this.sendCommand('next');
+  }
+
+  /**
+   * Go back to the previous track
+   */
+  public async previous(): Promise<void> {
+    await this.sendCommand('previous');
+  }
+
+  /**
+   * Set the volume
+   * @param volume Volume level (0-100)
+   */
+  public async setVolume(volume: number): Promise<void> {
+    await this.sendCommand('set_volume', { volume });
+  }
+
+  /**
+   * Get the current volume
+   */
+  public async getVolume(): Promise<number> {
+    const response = await this.sendCommand('get_volume');
+    return response.data.result;
+  }
+
+  /**
+   * Set repeat mode
+   * @param repeat Whether to enable repeat mode
+   */
+  public async setRepeat(repeat: boolean): Promise<void> {
+    await this.sendCommand('set_repeat', { repeat });
+  }
+
+  /**
+   * Set random mode
+   * @param random Whether to enable random mode
+   */
+  public async setRandom(random: boolean): Promise<void> {
+    await this.sendCommand('set_random', { random });
+  }
+
+  /**
+   * Get the current player status
+   */
+  public async getStatus(): Promise<PlayerStatus> {
+    const response = await this.sendCommand('get_status');
+    return response.data.result;
+  }
+
+  /**
+   * Get the available playlists
+   */
+  public async getPlaylists(): Promise<Playlist[]> {
+    const response = await this.sendCommand('get_playlists');
+    this.playlists = response.data.result;
+    this.emit(EventType.PLAYLIST_CHANGE, this.playlists);
+    return this.playlists;
+  }
+
+  /**
+   * Play a playlist
+   * @param playlist Playlist name
+   */
+  public async playPlaylist(playlist: string): Promise<void> {
+    await this.sendCommand('play_playlist', { playlist });
+  }
+
+  /**
+   * Get songs in a playlist
+   * @param playlist Playlist name
+   */
+  public async getPlaylistSongs(playlist: string): Promise<SongMetadata[]> {
+    const response = await this.sendCommand('get_playlist_songs', { playlist });
+    return response.data.result;
+  }
+
+  /**
+   * Create a playlist
+   * @param name Playlist name
+   * @param files List of files to add to the playlist
+   */
+  public async createPlaylist(name: string, files: string[]): Promise<void> {
+    await this.sendCommand('create_playlist', { name, files });
+  }
+
+  /**
+   * Delete a playlist
+   * @param playlist Playlist name
+   */
+  public async deletePlaylist(playlist: string): Promise<void> {
+    await this.sendCommand('delete_playlist', { playlist });
+  }
+
+  /**
+   * Update the music database
+   */
+  public async updateDatabase(): Promise<void> {
+    await this.sendCommand('update_database');
+  }
+
+  /**
+   * Play a specific track by index
+   * @param trackIndex Track index in the current playlist
+   */
+  public async playTrack(trackIndex: number): Promise<void> {
+    await this.sendCommand('play_track', { trackIndex });
+  }
+
+  /**
+   * Add a track to a playlist
+   * @param track Track to add
+   * @param playlist Playlist to add to
+   */
+  public async addTrack(track: string, playlist: string): Promise<void> {
+    await this.sendCommand('add_track', { track, playlist });
+  }
+
+  /**
+   * Remove a track from a playlist
+   * @param trackIndex Track index in the playlist
+   * @param playlist Playlist to remove from
+   */
+  public async removeTrack(trackIndex: number, playlist: string): Promise<void> {
+    await this.sendCommand('remove_track', { trackIndex, playlist });
+  }
+
+  /**
+   * Reorder tracks in a playlist
+   * @param fromIndex Original position
+   * @param toIndex New position
+   * @param playlist Playlist to reorder
+   */
+  public async reorderTrack(fromIndex: number, toIndex: number, playlist: string): Promise<void> {
+    await this.sendCommand('reorder_track', { fromIndex, toIndex, playlist });
+  }
+}

--- a/amora-sdk/client/src/index.test.ts
+++ b/amora-sdk/client/src/index.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for the Amora Client SDK
+ */
+
+import { AmoraClient, EventType, PlayerState, ConnectionStatus } from './index';
+
+// Mock the MQTT client
+jest.mock('mqtt', () => {
+  const EventEmitter = require('events');
+  
+  class MockMQTTClient extends EventEmitter {
+    connect = jest.fn().mockReturnValue(this);
+    subscribe = jest.fn().mockImplementation((topic, options, callback) => {
+      if (callback) callback(null);
+      return this;
+    });
+    publish = jest.fn().mockImplementation((topic, payload, options, callback) => {
+      if (callback) callback(null);
+      return this;
+    });
+    end = jest.fn().mockImplementation((force, callback) => {
+      if (callback) callback();
+      return this;
+    });
+  }
+  
+  return {
+    connect: jest.fn().mockImplementation(() => {
+      const client = new MockMQTTClient();
+      setTimeout(() => {
+        client.emit('connect');
+      }, 10);
+      return client;
+    })
+  };
+});
+
+describe('AmoraClient', () => {
+  let client: AmoraClient;
+  
+  beforeEach(() => {
+    client = new AmoraClient({
+      brokerUrl: 'localhost',
+      port: 1883,
+      deviceId: 'test-device'
+    });
+  });
+  
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  
+  describe('Connection', () => {
+    it('should connect to the MQTT broker', async () => {
+      const connectPromise = client.connect();
+      
+      // Wait for the connection to complete
+      await connectPromise;
+      
+      expect(client.getConnectionStatus()).toBe(ConnectionStatus.CONNECTED);
+    });
+    
+    it('should disconnect from the MQTT broker', async () => {
+      // Connect first
+      await client.connect();
+      
+      // Then disconnect
+      await client.disconnect();
+      
+      expect(client.getConnectionStatus()).toBe(ConnectionStatus.DISCONNECTED);
+    });
+  });
+  
+  describe('Event handling', () => {
+    it('should emit events when state changes', async () => {
+      // Connect first
+      await client.connect();
+      
+      // Set up event listener
+      const stateChangeHandler = jest.fn();
+      client.on(EventType.STATE_CHANGE, stateChangeHandler);
+      
+      // Simulate a state message
+      const stateMessage = {
+        state: PlayerState.PLAYING,
+        currentSong: {
+          title: 'Test Song',
+          artist: 'Test Artist',
+          album: 'Test Album',
+          duration: 180,
+          file: 'test.mp3'
+        },
+        volume: 80,
+        repeat: false,
+        random: false,
+        timestamp: Date.now()
+      };
+      
+      // Get the MQTT client instance
+      const mqttClient = (client as any).mqttClient.client;
+      
+      // Simulate receiving a message on the state topic
+      mqttClient.emit('message', 'amora/devices/test-device/state', Buffer.from(JSON.stringify(stateMessage)));
+      
+      // Check that the event was emitted
+      expect(stateChangeHandler).toHaveBeenCalledWith(PlayerState.PLAYING);
+      
+      // Check that the player status was updated
+      const status = client.getPlayerStatus();
+      expect(status.state).toBe(PlayerState.PLAYING);
+      expect(status.currentSong?.title).toBe('Test Song');
+      expect(status.volume).toBe(80);
+    });
+  });
+  
+  describe('Player controls', () => {
+    beforeEach(async () => {
+      // Connect first
+      await client.connect();
+    });
+    
+    it('should send play command', async () => {
+      // Set up a mock response
+      const mqttClient = (client as any).mqttClient.client;
+      
+      // Create a promise that resolves when the command is sent
+      const commandPromise = client.play();
+      
+      // Get the command ID from the pending commands
+      const pendingCommands = (client as any).pendingCommands;
+      const commandId = Array.from(pendingCommands.keys())[0];
+      
+      // Simulate a response
+      const responseMessage = {
+        commandId,
+        result: true,
+        message: 'Play command executed',
+        timestamp: Date.now()
+      };
+      
+      // Emit the response message
+      mqttClient.emit('message', 'amora/devices/test-device/responses', Buffer.from(JSON.stringify(responseMessage)));
+      
+      // Wait for the command to complete
+      await commandPromise;
+      
+      // Check that the command was sent
+      expect(mqttClient.publish).toHaveBeenCalled();
+      
+      // Check that the command was removed from pending commands
+      expect(pendingCommands.size).toBe(0);
+    });
+    
+    it('should handle command errors', async () => {
+      // Set up a mock response
+      const mqttClient = (client as any).mqttClient.client;
+      
+      // Create a promise that should reject
+      const commandPromise = client.play();
+      
+      // Get the command ID from the pending commands
+      const pendingCommands = (client as any).pendingCommands;
+      const commandId = Array.from(pendingCommands.keys())[0];
+      
+      // Simulate an error response
+      const responseMessage = {
+        commandId,
+        result: false,
+        message: 'Failed to play',
+        timestamp: Date.now()
+      };
+      
+      // Emit the response message
+      mqttClient.emit('message', 'amora/devices/test-device/responses', Buffer.from(JSON.stringify(responseMessage)));
+      
+      // Wait for the command to fail
+      await expect(commandPromise).rejects.toThrow('Failed to play');
+      
+      // Check that the command was removed from pending commands
+      expect(pendingCommands.size).toBe(0);
+    });
+  });
+  
+  describe('Playlist management', () => {
+    beforeEach(async () => {
+      // Connect first
+      await client.connect();
+    });
+    
+    it('should fetch playlists', async () => {
+      // Set up a mock response
+      const mqttClient = (client as any).mqttClient.client;
+      
+      // Create a promise that resolves when the command is sent
+      const commandPromise = client.getPlaylists();
+      
+      // Get the command ID from the pending commands
+      const pendingCommands = (client as any).pendingCommands;
+      const commandId = Array.from(pendingCommands.keys())[0];
+      
+      // Simulate a response with playlists
+      const responseMessage = {
+        commandId,
+        result: true,
+        message: 'Playlists retrieved',
+        data: {
+          result: [
+            {
+              name: 'Playlist 1',
+              items: [
+                {
+                  title: 'Song 1',
+                  artist: 'Artist 1',
+                  album: 'Album 1',
+                  duration: 180,
+                  file: 'song1.mp3',
+                  position: 0,
+                  isCurrent: true
+                }
+              ]
+            }
+          ]
+        },
+        timestamp: Date.now()
+      };
+      
+      // Emit the response message
+      mqttClient.emit('message', 'amora/devices/test-device/responses', Buffer.from(JSON.stringify(responseMessage)));
+      
+      // Wait for the command to complete
+      const playlists = await commandPromise;
+      
+      // Check that the playlists were returned
+      expect(playlists).toHaveLength(1);
+      expect(playlists[0].name).toBe('Playlist 1');
+      expect(playlists[0].items).toHaveLength(1);
+      expect(playlists[0].items[0].title).toBe('Song 1');
+      
+      // Check that the playlists were stored
+      expect(client.getPlaylists()).toEqual(playlists);
+    });
+  });
+});

--- a/amora-sdk/client/src/index.ts
+++ b/amora-sdk/client/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Amora Client SDK
+ * 
+ * A TypeScript/JavaScript SDK for controlling Amora music player devices through MQTT.
+ */
+
+// Export main client class
+export { AmoraClient } from './amora-client';
+
+// Export types and interfaces
+export {
+  AmoraClientConfig,
+  ConnectionOptions,
+  QoS,
+  PlayerState,
+  SongMetadata,
+  PlayerStatus,
+  PlaylistItem,
+  Playlist,
+  CommandMessage,
+  ResponseMessage,
+  StateMessage,
+  ConnectionStatus,
+  EventType,
+  EventListener,
+  TopicType
+} from './types';
+
+// Export utility functions
+export { createCommandMessage, parseMessage, createStateMessage } from './messages';
+
+// Export MQTT client and topic manager (for advanced usage)
+export { MQTTClient } from './mqtt-client';
+export { TopicManager } from './topic-manager';

--- a/amora-sdk/client/src/messages.ts
+++ b/amora-sdk/client/src/messages.ts
@@ -1,0 +1,82 @@
+/**
+ * Message handling utilities for the Amora Client SDK
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { 
+  CommandMessage, 
+  ResponseMessage, 
+  StateMessage, 
+  PlayerState,
+  SongMetadata
+} from './types';
+
+/**
+ * Create a command message
+ * @param command Command name
+ * @param params Command parameters
+ * @returns Command message
+ */
+export function createCommandMessage(command: string, params?: any): CommandMessage {
+  return {
+    command,
+    commandId: uuidv4(),
+    params,
+    timestamp: Date.now()
+  };
+}
+
+/**
+ * Parse a message payload
+ * @param payload Message payload
+ * @returns Parsed message or null if parsing failed
+ */
+export function parseMessage(payload: Buffer | string): CommandMessage | ResponseMessage | StateMessage | null {
+  try {
+    // Convert buffer to string if needed
+    const payloadStr = payload instanceof Buffer ? payload.toString() : payload;
+    
+    // Parse JSON
+    const data = JSON.parse(payloadStr);
+    
+    // Determine message type
+    if ('command' in data && 'commandId' in data) {
+      return data as CommandMessage;
+    } else if ('result' in data && 'commandId' in data) {
+      return data as ResponseMessage;
+    } else if ('state' in data) {
+      return data as StateMessage;
+    }
+    
+    return null;
+  } catch (error) {
+    console.error('Error parsing message:', error);
+    return null;
+  }
+}
+
+/**
+ * Create a state message from player status
+ * @param state Player state
+ * @param currentSong Current song
+ * @param volume Current volume
+ * @param repeat Whether repeat mode is enabled
+ * @param random Whether random mode is enabled
+ * @returns State message
+ */
+export function createStateMessage(
+  state: PlayerState,
+  currentSong?: SongMetadata,
+  volume = 0,
+  repeat = false,
+  random = false
+): StateMessage {
+  return {
+    state,
+    currentSong,
+    volume,
+    repeat,
+    random,
+    timestamp: Date.now()
+  };
+}

--- a/amora-sdk/client/src/mqtt-client.ts
+++ b/amora-sdk/client/src/mqtt-client.ts
@@ -1,0 +1,257 @@
+/**
+ * MQTT client wrapper for the Amora Client SDK
+ */
+
+import * as mqtt from 'mqtt';
+import { EventEmitter } from 'events';
+import { AmoraClientConfig, ConnectionOptions, QoS, ConnectionStatus } from './types';
+
+/**
+ * MQTT client wrapper for the Amora Client SDK
+ */
+export class MQTTClient extends EventEmitter {
+  private client: mqtt.MqttClient | null = null;
+  private config: AmoraClientConfig;
+  private connectionStatus: ConnectionStatus = ConnectionStatus.DISCONNECTED;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private reconnectDelay = 1000; // Initial reconnect delay in ms
+
+  /**
+   * Create a new MQTT client
+   * @param config Client configuration
+   */
+  constructor(config: AmoraClientConfig) {
+    super();
+    this.config = {
+      ...config,
+      clientId: config.clientId || `amora-client-${Date.now()}`,
+      topicPrefix: config.topicPrefix || 'amora/devices',
+      defaultQoS: config.defaultQoS || QoS.AT_LEAST_ONCE,
+      connectionOptions: {
+        keepAlive: 60,
+        cleanSession: true,
+        reconnectOnFailure: true,
+        maxReconnectDelay: 300,
+        ...config.connectionOptions
+      }
+    };
+  }
+
+  /**
+   * Get the connection status
+   */
+  public getConnectionStatus(): ConnectionStatus {
+    return this.connectionStatus;
+  }
+
+  /**
+   * Connect to the MQTT broker
+   * @returns Promise that resolves when connected
+   */
+  public connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.client && this.connectionStatus === ConnectionStatus.CONNECTED) {
+        resolve();
+        return;
+      }
+
+      this.setConnectionStatus(ConnectionStatus.CONNECTING);
+
+      // Build connection options
+      const options: mqtt.IClientOptions = {
+        clientId: this.config.clientId,
+        keepalive: this.config.connectionOptions?.keepAlive || 60,
+        clean: this.config.connectionOptions?.cleanSession !== false,
+        reconnectPeriod: this.config.connectionOptions?.reconnectOnFailure === false ? 0 : 1000,
+        username: this.config.connectionOptions?.username,
+        password: this.config.connectionOptions?.password,
+        protocol: this.config.connectionOptions?.useTls ? 'mqtts' : 'mqtt'
+      };
+
+      // Add TLS options if needed
+      if (this.config.connectionOptions?.useTls) {
+        options.rejectUnauthorized = true;
+        
+        if (this.config.connectionOptions.caCertPath) {
+          options.ca = [this.config.connectionOptions.caCertPath];
+        }
+        
+        if (this.config.connectionOptions.clientCertPath && this.config.connectionOptions.clientKeyPath) {
+          options.cert = this.config.connectionOptions.clientCertPath;
+          options.key = this.config.connectionOptions.clientKeyPath;
+        }
+      }
+
+      // Create MQTT client
+      const url = `${this.config.connectionOptions?.useTls ? 'mqtts' : 'mqtt'}://${this.config.brokerUrl}:${this.config.port}`;
+      this.client = mqtt.connect(url, options);
+
+      // Set up event handlers
+      this.client.on('connect', () => {
+        this.setConnectionStatus(ConnectionStatus.CONNECTED);
+        this.reconnectDelay = 1000; // Reset reconnect delay
+        resolve();
+      });
+
+      this.client.on('error', (error) => {
+        this.emit('error', error);
+        if (this.connectionStatus === ConnectionStatus.CONNECTING) {
+          reject(error);
+        }
+      });
+
+      this.client.on('offline', () => {
+        this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+      });
+
+      this.client.on('reconnect', () => {
+        this.setConnectionStatus(ConnectionStatus.CONNECTING);
+      });
+
+      this.client.on('message', (topic, payload) => {
+        this.emit('message', topic, payload);
+      });
+
+      this.client.on('close', () => {
+        this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+        
+        // If reconnect is disabled, try to reconnect manually
+        if (this.config.connectionOptions?.reconnectOnFailure !== false && 
+            options.reconnectPeriod === 0) {
+          this.scheduleReconnect();
+        }
+      });
+    });
+  }
+
+  /**
+   * Disconnect from the MQTT broker
+   */
+  public disconnect(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.client || this.connectionStatus === ConnectionStatus.DISCONNECTED) {
+        resolve();
+        return;
+      }
+
+      // Clear reconnect timer
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
+
+      this.client.end(false, () => {
+        this.setConnectionStatus(ConnectionStatus.DISCONNECTED);
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Subscribe to a topic
+   * @param topic Topic to subscribe to
+   * @param qos QoS level
+   */
+  public subscribe(topic: string, qos: QoS = this.config.defaultQoS || QoS.AT_LEAST_ONCE): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.client || this.connectionStatus !== ConnectionStatus.CONNECTED) {
+        reject(new Error('Not connected to MQTT broker'));
+        return;
+      }
+
+      this.client.subscribe(topic, { qos }, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Unsubscribe from a topic
+   * @param topic Topic to unsubscribe from
+   */
+  public unsubscribe(topic: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.client || this.connectionStatus !== ConnectionStatus.CONNECTED) {
+        reject(new Error('Not connected to MQTT broker'));
+        return;
+      }
+
+      this.client.unsubscribe(topic, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Publish a message to a topic
+   * @param topic Topic to publish to
+   * @param payload Message payload
+   * @param qos QoS level
+   * @param retain Whether to retain the message
+   */
+  public publish(
+    topic: string, 
+    payload: string | Buffer | object, 
+    qos: QoS = this.config.defaultQoS || QoS.AT_LEAST_ONCE, 
+    retain = false
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.client || this.connectionStatus !== ConnectionStatus.CONNECTED) {
+        reject(new Error('Not connected to MQTT broker'));
+        return;
+      }
+
+      // Convert object to JSON string
+      let messagePayload = payload;
+      if (typeof payload === 'object' && !(payload instanceof Buffer)) {
+        messagePayload = JSON.stringify(payload);
+      }
+
+      this.client.publish(topic, messagePayload as string | Buffer, { qos, retain }, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Set the connection status and emit an event
+   * @param status New connection status
+   */
+  private setConnectionStatus(status: ConnectionStatus): void {
+    if (this.connectionStatus !== status) {
+      this.connectionStatus = status;
+      this.emit('connectionChange', status);
+    }
+  }
+
+  /**
+   * Schedule a reconnection attempt
+   */
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+    }
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect().catch(() => {
+        // Increase reconnect delay with exponential backoff, up to max
+        const maxDelay = (this.config.connectionOptions?.maxReconnectDelay || 300) * 1000;
+        this.reconnectDelay = Math.min(this.reconnectDelay * 2, maxDelay);
+        this.scheduleReconnect();
+      });
+    }, this.reconnectDelay);
+  }
+}

--- a/amora-sdk/client/src/topic-manager.ts
+++ b/amora-sdk/client/src/topic-manager.ts
@@ -1,0 +1,91 @@
+/**
+ * Topic manager for the Amora Client SDK
+ */
+
+import { TopicType } from './types';
+
+/**
+ * Manages MQTT topics for the Amora Client SDK
+ */
+export class TopicManager {
+  private topicPrefix: string;
+  private deviceId: string;
+  private validTopics: Set<string> = new Set();
+
+  /**
+   * Create a new topic manager
+   * @param topicPrefix Prefix for all topics
+   * @param deviceId Device ID
+   */
+  constructor(topicPrefix: string, deviceId: string) {
+    this.topicPrefix = topicPrefix;
+    this.deviceId = deviceId;
+    this.initializeValidTopics();
+  }
+
+  /**
+   * Initialize the set of valid topics
+   */
+  private initializeValidTopics(): void {
+    Object.values(TopicType).forEach(topicType => {
+      this.validTopics.add(this.getTopic(topicType));
+    });
+  }
+
+  /**
+   * Get the full topic string for a given topic type
+   * @param topicType Type of the topic
+   * @returns Full topic string
+   */
+  public getTopic(topicType: TopicType): string {
+    return `${this.topicPrefix}/${this.deviceId}/${topicType}`;
+  }
+
+  /**
+   * Check if a topic is valid
+   * @param topic Topic to check
+   * @returns True if the topic is valid, false otherwise
+   */
+  public isValidTopic(topic: string): boolean {
+    return this.validTopics.has(topic);
+  }
+
+  /**
+   * Parse a topic string and return its type
+   * @param topic Topic string to parse
+   * @returns TopicType if the topic is valid, undefined otherwise
+   */
+  public parseTopic(topic: string): TopicType | undefined {
+    if (!this.isValidTopic(topic)) {
+      return undefined;
+    }
+
+    // Extract the topic type from the topic string
+    const parts = topic.split('/');
+    if (parts.length < 3) {
+      return undefined;
+    }
+
+    const topicTypeStr = parts[parts.length - 1];
+    return Object.values(TopicType).find(t => t === topicTypeStr);
+  }
+
+  /**
+   * Get the list of topics to subscribe to
+   * @returns List of topics to subscribe to
+   */
+  public getSubscriptionTopics(): string[] {
+    return [
+      this.getTopic(TopicType.STATE),
+      this.getTopic(TopicType.RESPONSES)
+    ];
+  }
+
+  /**
+   * Get a wildcard topic for the device
+   * @returns Wildcard topic string
+   */
+  public getWildcardTopic(): string {
+    return `${this.topicPrefix}/${this.deviceId}/#`;
+  }
+}

--- a/amora-sdk/client/src/types.ts
+++ b/amora-sdk/client/src/types.ts
@@ -1,0 +1,222 @@
+/**
+ * Types and interfaces for the Amora Client SDK
+ */
+
+/**
+ * Quality of Service level for MQTT messages
+ */
+export enum QoS {
+  AT_MOST_ONCE = 0,
+  AT_LEAST_ONCE = 1,
+  EXACTLY_ONCE = 2
+}
+
+/**
+ * Connection options for MQTT client
+ */
+export interface ConnectionOptions {
+  /** Username for MQTT broker authentication */
+  username?: string;
+  /** Password for MQTT broker authentication */
+  password?: string;
+  /** Whether to use TLS for the connection */
+  useTls?: boolean;
+  /** Path to CA certificate file for TLS */
+  caCertPath?: string;
+  /** Path to client certificate file for TLS */
+  clientCertPath?: string;
+  /** Path to client key file for TLS */
+  clientKeyPath?: string;
+  /** Keep alive interval in seconds */
+  keepAlive?: number;
+  /** Whether to use a clean session */
+  cleanSession?: boolean;
+  /** Whether to reconnect automatically on connection failure */
+  reconnectOnFailure?: boolean;
+  /** Maximum reconnect delay in seconds */
+  maxReconnectDelay?: number;
+}
+
+/**
+ * Configuration for the Amora Client SDK
+ */
+export interface AmoraClientConfig {
+  /** MQTT broker URL */
+  brokerUrl: string;
+  /** MQTT broker port */
+  port: number;
+  /** Client ID for MQTT connection */
+  clientId?: string;
+  /** Device ID to connect to */
+  deviceId: string;
+  /** Topic prefix for MQTT topics */
+  topicPrefix?: string;
+  /** Connection options for MQTT client */
+  connectionOptions?: ConnectionOptions;
+  /** Default QoS level for MQTT messages */
+  defaultQoS?: QoS;
+  /** Status updater configuration */
+  statusUpdater?: {
+    /** Update interval in seconds */
+    updateInterval?: number;
+    /** Position update interval in seconds */
+    positionUpdateInterval?: number;
+    /** Full update interval in seconds */
+    fullUpdateInterval?: number;
+  };
+}
+
+/**
+ * Player state
+ */
+export enum PlayerState {
+  PLAYING = 'play',
+  PAUSED = 'pause',
+  STOPPED = 'stop',
+  LOADING = 'loading',
+  ERROR = 'error'
+}
+
+/**
+ * Song metadata
+ */
+export interface SongMetadata {
+  /** Song title */
+  title: string;
+  /** Artist name */
+  artist: string;
+  /** Album name */
+  album: string;
+  /** Album art URL */
+  albumArt?: string;
+  /** Song duration in seconds */
+  duration: number;
+  /** Current position in seconds */
+  position?: number;
+  /** File path or URL */
+  file: string;
+  /** Additional metadata */
+  [key: string]: any;
+}
+
+/**
+ * Player status
+ */
+export interface PlayerStatus {
+  /** Current player state */
+  state: PlayerState;
+  /** Current song metadata */
+  currentSong?: SongMetadata;
+  /** Current volume (0-100) */
+  volume: number;
+  /** Whether repeat mode is enabled */
+  repeat: boolean;
+  /** Whether random mode is enabled */
+  random: boolean;
+}
+
+/**
+ * Playlist item
+ */
+export interface PlaylistItem extends SongMetadata {
+  /** Position in the playlist */
+  position: number;
+  /** Whether this is the current song */
+  isCurrent: boolean;
+}
+
+/**
+ * Playlist
+ */
+export interface Playlist {
+  /** Playlist name */
+  name: string;
+  /** Playlist items */
+  items: PlaylistItem[];
+}
+
+/**
+ * Command message
+ */
+export interface CommandMessage {
+  /** Command name */
+  command: string;
+  /** Command ID */
+  commandId: string;
+  /** Command parameters */
+  params?: any;
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * Response message
+ */
+export interface ResponseMessage {
+  /** Command ID that this response is for */
+  commandId: string;
+  /** Whether the command was successful */
+  result: boolean;
+  /** Response message */
+  message: string;
+  /** Response data */
+  data?: any;
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * State message
+ */
+export interface StateMessage {
+  /** Player state */
+  state: PlayerState;
+  /** Current song */
+  currentSong?: SongMetadata;
+  /** Current volume */
+  volume: number;
+  /** Whether repeat mode is enabled */
+  repeat: boolean;
+  /** Whether random mode is enabled */
+  random: boolean;
+  /** Timestamp */
+  timestamp: number;
+}
+
+/**
+ * Connection status
+ */
+export enum ConnectionStatus {
+  CONNECTED = 'connected',
+  DISCONNECTED = 'disconnected',
+  CONNECTING = 'connecting',
+  ERROR = 'error'
+}
+
+/**
+ * Event types
+ */
+export enum EventType {
+  STATE_CHANGE = 'stateChange',
+  POSITION_CHANGE = 'positionChange',
+  VOLUME_CHANGE = 'volumeChange',
+  PLAYLIST_CHANGE = 'playlistChange',
+  CONNECTION_CHANGE = 'connectionChange',
+  COMMAND_RESPONSE = 'commandResponse',
+  ERROR = 'error'
+}
+
+/**
+ * Event listener
+ */
+export type EventListener = (data: any) => void;
+
+/**
+ * Topic type
+ */
+export enum TopicType {
+  STATE = 'state',
+  COMMANDS = 'commands',
+  RESPONSES = 'responses',
+  CONNECTION = 'connection'
+}

--- a/amora-sdk/client/tsconfig.json
+++ b/amora-sdk/client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}


### PR DESCRIPTION
This PR updates the Amora Client SDK to match the new API schema in the main branch. The changes include:

1. Updated command names to use snake_case instead of camelCase to match the Python API
2. Added new methods to match the updated player API
3. Updated message formats to match the new API
4. Improved error handling and connection management
5. Updated documentation and examples

The client SDK now supports all the commands available in the new music player application:
- play, pause, stop, next, previous
- set_volume, get_volume
- get_status, get_playlists
- play_playlist, set_repeat, set_random
- create_playlist, delete_playlist, get_playlist_songs
- update_database
- playTrack, addTrack, removeTrack, reorderTrack

This implementation replaces PR #3 which was based on an older version of the API.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author